### PR TITLE
Validating codex api key according to deployments configured

### DIFF
--- a/src/codex/codex.module.ts
+++ b/src/codex/codex.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CodexService } from './codex.service';
 import { ConfigModule } from '@nestjs/config';
+import { DeploymentModule } from 'src/deployment/deployment.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, DeploymentModule],
   providers: [CodexService],
   exports: [CodexService],
 })


### PR DESCRIPTION
This PR is to make sure the application validates if there is a CODEX api key according to the deployments (networks) configured.
The backend uses CODEX api when getting quotes for chains different than Ethereum. 

As its currently setup, if there is no Codex api key => an error is thrown when instantiating Codex sdk. 
Even if there is only 1 deployment configured and its Ethereum, the application still errors in the same place, although it should work as Codex api won't be used.

This PR fixes this so it allows the application to run without a codex api key if Ethereum is the only network
And it throws an error if this api key is required by the deployments configured, but not present in the .env file. 