### PR TITLE
Make sure we only poll historic quotes for configured deployments

### DIFF
--- a/src/historic-quote/historic-quote.service.ts
+++ b/src/historic-quote/historic-quote.service.ts
@@ -50,11 +50,17 @@ export class HistoricQuoteService implements OnModuleInit {
     this.isPolling = true;
 
     try {
-      await Promise.all([
-        await this.updateCoinMarketCapQuotes(),
-        await this.updateCodexQuotes(BlockchainType.Sei, SEI_NETWORK_ID),
-        await this.updateCodexQuotes(BlockchainType.Celo, CELO_NETWORK_ID),
-      ]);
+      const deployments = this.deploymentService.getDeployments();
+      const promises = deployments.map((deployment) => {
+        if (deployment.blockchainType === BlockchainType.Ethereum) {
+          return this.updateCoinMarketCapQuotes();
+        } else if (deployment.blockchainType === BlockchainType.Sei) {
+          return this.updateCodexQuotes(BlockchainType.Sei, SEI_NETWORK_ID);
+        } else if (deployment.blockchainType === BlockchainType.Celo) {
+          return this.updateCodexQuotes(BlockchainType.Celo, CELO_NETWORK_ID);
+        }
+      });
+      await Promise.all(promises);
     } catch (error) {
       console.error('Error updating historic quotes:', error);
       this.isPolling = false;


### PR DESCRIPTION
Currently polling historic quotes is hardcoded to always poll for Ethereum, Sei and Celo networks, despite of the deployments configured. 
If one of these networks deployment is not configured, the application errors when polling for that network. 

This PR makes sure that we'll only poll historical quotes for the deployments configured.