### PR TITLE
added provider fallback for historic rates

### DIFF
--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -6,6 +6,7 @@ import { Deployment, NATIVE_TOKEN } from '../deployment/deployment.service';
 
 export const SEI_NETWORK_ID = 531;
 export const CELO_NETWORK_ID = 42220;
+export const ETHEREUM_NETWORK_ID = 1;
 
 @Injectable()
 export class CodexService {
@@ -16,8 +17,11 @@ export class CodexService {
     this.sdk = new Codex(apiKey);
   }
 
-  async getLatestPrices(deployment: Deployment, networkId: number, addresses: string[]): Promise<any> {
-    const originalAddresses = [...addresses]; // Keep a copy of the original addresses to return correct keys
+  async getLatestPrices(deployment: Deployment, addresses: string[]): Promise<any> {
+    const networkId = this.getNetworkId(deployment.blockchainType);
+    if (!networkId) return null;
+
+    const originalAddresses = [...addresses];
     let nativeTokenAliasUsed = false;
 
     // Replace only if targetAddress (NATIVE_TOKEN) is present in addresses
@@ -143,5 +147,18 @@ export class CodexService {
     } while (fetched.length === limit);
 
     return allTokens;
+  }
+
+  private getNetworkId(blockchainType: string): number {
+    switch (blockchainType) {
+      case 'sei':
+        return SEI_NETWORK_ID;
+      case 'celo':
+        return CELO_NETWORK_ID;
+      case 'ethereum':
+        return ETHEREUM_NETWORK_ID;
+      default:
+        return null;
+    }
   }
 }

--- a/src/historic-quote/historic-quote.controller.ts
+++ b/src/historic-quote/historic-quote.controller.ts
@@ -52,6 +52,7 @@ export class HistoricQuoteController {
         high: p.high.toString(),
         open: p.open.toString(),
         close: p.close.toString(),
+        provider: p.provider,
       });
     });
 

--- a/src/historic-quote/historic-quote.service.ts
+++ b/src/historic-quote/historic-quote.service.ts
@@ -407,6 +407,12 @@ export class HistoricQuoteService implements OnModuleInit {
     data[tokenA].forEach((_, i) => {
       const base = data[tokenA][i];
       const quote = data[tokenB][i];
+
+      // Skip if either close price is null
+      if (base.close === null || quote.close === null) {
+        return;
+      }
+
       prices.push({
         timestamp: base.timestamp,
         usd: new Decimal(base.close).div(quote.close),
@@ -479,15 +485,6 @@ export class HistoricQuoteService implements OnModuleInit {
     }
 
     return candlesticks;
-  }
-
-  private findFirstNonNullOpenIndex(candles: Candlestick[]): number {
-    for (let i = 0; i < candles.length; i++) {
-      if (candles[i].open !== null) {
-        return i;
-      }
-    }
-    return -1; // If no non-null open value found
   }
 
   async getUsdRates(deployment: Deployment, addresses: string[], start: string, end: string): Promise<any[]> {

--- a/src/historic-quote/historic-quote.service.ts
+++ b/src/historic-quote/historic-quote.service.ts
@@ -20,14 +20,14 @@ type Candlestick = {
   provider: string;
 };
 
-type PriceProvider = 'coinmarketcap' | 'codex';
+type PriceProvider = 'coinmarketcap' | 'codex' | 'coingecko';
 
 interface ProviderConfig {
   name: PriceProvider;
   enabled: boolean;
 }
 
-type BlockchainProviderConfig = {
+export type BlockchainProviderConfig = {
   [key in BlockchainType]: ProviderConfig[];
 };
 

--- a/src/historic-quote/historic-quote.service.ts
+++ b/src/historic-quote/historic-quote.service.ts
@@ -109,7 +109,7 @@ export class HistoricQuoteService implements OnModuleInit {
     const deployment = this.deploymentService.getDeploymentByBlockchainType(blockchainType);
     const latest = await this.getLatest(blockchainType);
     const addresses = await this.codexService.getAllTokenAddresses(networkId);
-    const quotes = await this.codexService.getLatestPrices(deployment, networkId, addresses);
+    const quotes = await this.codexService.getLatestPrices(deployment, addresses);
     const newQuotes = [];
 
     for (const address of Object.keys(quotes)) {

--- a/src/quote/coingecko.service.ts
+++ b/src/quote/coingecko.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 import { Deployment } from '../deployment/deployment.service';
 
 @Injectable()
 export class CoinGeckoService {
+  private readonly logger = new Logger(CoinGeckoService.name);
   constructor(private configService: ConfigService) {}
 
   private readonly baseURL = 'https://pro-api.coingecko.com/api/v3';
@@ -47,6 +48,20 @@ export class CoinGeckoService {
       return result;
     } catch (error) {
       throw new Error(`Failed to fetch latest token prices: ${error.message}`);
+    }
+  }
+
+  async fetchLatestPrice(deployment: Deployment, address: string, convert = ['usd']): Promise<any> {
+    try {
+      let price;
+      if (address.toLowerCase() === deployment.gasToken.address.toLowerCase()) {
+        price = await this.getLatestGasTokenPrice(deployment, convert);
+      } else {
+        price = await this.getLatestPrices([address], deployment, convert);
+      }
+      return price;
+    } catch (error) {
+      this.logger.error(`Error fetching price: ${error.message}`);
     }
   }
 

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -97,20 +97,6 @@ export class QuoteService implements OnModuleInit {
     return tokensByAddress;
   }
 
-  async fetchLatestPrice(deployment: Deployment, address: string, convert = ['usd']): Promise<any> {
-    try {
-      let price;
-      if (address.toLowerCase() === deployment.gasToken.address.toLowerCase()) {
-        price = await this.coingeckoService.getLatestGasTokenPrice(deployment, convert);
-      } else {
-        price = await this.coingeckoService.getLatestPrices([address], deployment, convert);
-      }
-      return price;
-    } catch (error) {
-      this.logger.error(`Error fetching price: ${error.message}`);
-    }
-  }
-
   private async updateQuotes(tokens: Token[], newPrices: Record<string, any>, deployment: Deployment): Promise<void> {
     const existingQuotes = await this.quoteRepository.find();
     const quoteEntities: Quote[] = [];

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -155,12 +155,11 @@ export class QuoteService implements OnModuleInit {
       try {
         data = await this.fetchPriceFromProvider(provider.name, deployment, address, currencies);
 
-        if (
-          data &&
-          Object.keys(data).length > 0 &&
-          data[addressLower] &&
-          Object.keys(data[addressLower]).some((key) => key !== 'provider' && key !== 'last_updated_at')
-        ) {
+        const hasValidPriceData = Object.keys(data[addressLower]).some(
+          (key) => key !== 'provider' && key !== 'last_updated_at',
+        );
+
+        if (data && Object.keys(data).length > 0 && data[addressLower] && hasValidPriceData) {
           usedProvider = provider.name;
           break;
         }

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -140,6 +140,7 @@ export class QuoteService implements OnModuleInit {
 
   async getLatestPrice(deployment: Deployment, address: string, currencies: string[]): Promise<any> {
     const enabledProviders = this.priceProviders[deployment.blockchainType].filter((p) => p.enabled);
+    const addressLower = address.toLowerCase();
 
     let data = null;
     let usedProvider = null;
@@ -157,8 +158,8 @@ export class QuoteService implements OnModuleInit {
         if (
           data &&
           Object.keys(data).length > 0 &&
-          data[address.toLowerCase()] &&
-          Object.keys(data[address.toLowerCase()]).some((key) => key !== 'provider' && key !== 'last_updated_at')
+          data[addressLower] &&
+          Object.keys(data[addressLower]).some((key) => key !== 'provider' && key !== 'last_updated_at')
         ) {
           usedProvider = provider.name;
           break;
@@ -180,8 +181,8 @@ export class QuoteService implements OnModuleInit {
     };
 
     currencies.forEach((c) => {
-      if (data[address.toLowerCase()] && data[address.toLowerCase()][c.toLowerCase()]) {
-        result.data[c.toUpperCase()] = data[address.toLowerCase()][c.toLowerCase()];
+      if (data[addressLower] && data[addressLower][c.toLowerCase()]) {
+        result.data[c.toUpperCase()] = data[addressLower][c.toLowerCase()];
       }
     });
 

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -205,19 +205,6 @@ export class QuoteService implements OnModuleInit {
     }
   }
 
-  private getNetworkId(blockchainType: BlockchainType): number | null {
-    switch (blockchainType) {
-      case BlockchainType.Sei:
-        return SEI_NETWORK_ID;
-      case BlockchainType.Celo:
-        return CELO_NETWORK_ID;
-      case BlockchainType.Ethereum:
-        return ETHEREUM_NETWORK_ID;
-      default:
-        return null;
-    }
-  }
-
   private async shouldSkipProvider(blockchainType: string, address: string, provider: string): Promise<boolean> {
     const key = `skip:${blockchainType}:${address}:${provider}`;
     return (await this.redis.get(key)) === '1';

--- a/src/v1/market-rate/market-rate.controller.ts
+++ b/src/v1/market-rate/market-rate.controller.ts
@@ -44,10 +44,7 @@ export class MarketRateController {
       try {
         switch (provider.name) {
           case 'codex':
-            const networkId = this.getNetworkId(deployment.blockchainType);
-            if (networkId) {
-              data = await this.codexService.getLatestPrices(deployment, networkId, [address]);
-            }
+            data = await this.codexService.getLatestPrices(deployment, [address]);
             break;
           case 'coingecko':
             data = await this.coinGeckoService.fetchLatestPrice(deployment, address, currencies);
@@ -85,18 +82,5 @@ export class MarketRateController {
     });
 
     return result;
-  }
-
-  private getNetworkId(blockchainType: BlockchainType): number | null {
-    switch (blockchainType) {
-      case BlockchainType.Sei:
-        return SEI_NETWORK_ID;
-      case BlockchainType.Celo:
-        return CELO_NETWORK_ID;
-      case BlockchainType.Ethereum:
-        return ETHEREUM_NETWORK_ID;
-      default:
-        return null;
-    }
   }
 }

--- a/src/v1/market-rate/market-rate.controller.ts
+++ b/src/v1/market-rate/market-rate.controller.ts
@@ -51,12 +51,12 @@ export class MarketRateController {
             break;
         }
 
-        if (
-          data &&
-          Object.keys(data).length > 0 &&
-          data[address.toLowerCase()] &&
-          Object.keys(data[address.toLowerCase()]).some((key) => key !== 'provider' && key !== 'last_updated_at')
-        ) {
+        const addressLower = address.toLowerCase();
+        const hasValidPriceData = Object.keys(data[addressLower]).some(
+          (key) => key !== 'provider' && key !== 'last_updated_at',
+        );
+
+        if (data && Object.keys(data).length > 0 && data[addressLower] && hasValidPriceData) {
           usedProvider = provider.name;
           break;
         }

--- a/src/v1/market-rate/market-rate.controller.ts
+++ b/src/v1/market-rate/market-rate.controller.ts
@@ -1,18 +1,29 @@
 import { Controller, Get, Header, Query } from '@nestjs/common';
 import { MarketRateDto } from './market-rate.dto';
-import { QuoteService } from '../../quote/quote.service';
 import { CacheTTL } from '@nestjs/cache-manager';
 import { DeploymentService, ExchangeId } from '../../deployment/deployment.service';
 import { BlockchainType, Deployment } from '../../deployment/deployment.service';
 import { ApiExchangeIdParam, ExchangeIdParam } from '../../exchange-id-param.decorator';
-import { CELO_NETWORK_ID, CodexService, SEI_NETWORK_ID } from '../../codex/codex.service';
+import { CELO_NETWORK_ID, CodexService, ETHEREUM_NETWORK_ID, SEI_NETWORK_ID } from '../../codex/codex.service';
+import { CoinGeckoService } from '../../quote/coingecko.service';
+import { BlockchainProviderConfig } from '../../historic-quote/historic-quote.service';
 
 @Controller({ version: '1', path: ':exchangeId?/market-rate' })
 export class MarketRateController {
+  private priceProviders: BlockchainProviderConfig = {
+    [BlockchainType.Ethereum]: [
+      { name: 'coingecko', enabled: true },
+      { name: 'codex', enabled: true },
+    ],
+    [BlockchainType.Sei]: [{ name: 'codex', enabled: true }],
+    [BlockchainType.Celo]: [{ name: 'codex', enabled: true }],
+    [BlockchainType.Blast]: [{ name: 'codex', enabled: true }],
+  };
+
   constructor(
-    private quoteService: QuoteService,
     private deploymentService: DeploymentService,
     private codexService: CodexService,
+    private coinGeckoService: CoinGeckoService,
   ) {}
 
   @Get('')
@@ -23,24 +34,69 @@ export class MarketRateController {
     const deployment: Deployment = await this.deploymentService.getDeploymentByExchangeId(exchangeId);
     const { address, convert } = params;
     const currencies = convert.split(',');
-    let data;
 
-    if (deployment.blockchainType === BlockchainType.Sei) {
-      data = await this.codexService.getLatestPrices(deployment, SEI_NETWORK_ID, [address]);
-    } else if (deployment.blockchainType === BlockchainType.Celo) {
-      data = await this.codexService.getLatestPrices(deployment, CELO_NETWORK_ID, [address]);
-    } else {
-      data = await this.quoteService.fetchLatestPrice(deployment, address, currencies);
+    const enabledProviders = this.priceProviders[deployment.blockchainType].filter((p) => p.enabled);
+
+    let data = null;
+    let usedProvider = null;
+
+    for (const provider of enabledProviders) {
+      try {
+        switch (provider.name) {
+          case 'codex':
+            const networkId = this.getNetworkId(deployment.blockchainType);
+            if (networkId) {
+              data = await this.codexService.getLatestPrices(deployment, networkId, [address]);
+            }
+            break;
+          case 'coingecko':
+            data = await this.coinGeckoService.fetchLatestPrice(deployment, address, currencies);
+            break;
+        }
+
+        if (
+          data &&
+          Object.keys(data).length > 0 &&
+          data[address.toLowerCase()] &&
+          Object.keys(data[address.toLowerCase()]).some((key) => key !== 'provider' && key !== 'last_updated_at')
+        ) {
+          usedProvider = provider.name;
+          break;
+        }
+      } catch (error) {
+        console.error(`Error fetching price from ${provider.name}:`, error);
+      }
+      data = null;
+    }
+
+    if (!data || Object.keys(data).length === 0) {
+      throw new Error(`No price data available for token: ${address}`);
     }
 
     const result = {
       data: {},
+      provider: usedProvider,
     };
+
     currencies.forEach((c) => {
       if (data[address.toLowerCase()] && data[address.toLowerCase()][c.toLowerCase()]) {
-        result['data'][c.toUpperCase()] = data[address.toLowerCase()][c.toLowerCase()];
+        result.data[c.toUpperCase()] = data[address.toLowerCase()][c.toLowerCase()];
       }
     });
+
     return result;
+  }
+
+  private getNetworkId(blockchainType: BlockchainType): number | null {
+    switch (blockchainType) {
+      case BlockchainType.Sei:
+        return SEI_NETWORK_ID;
+      case BlockchainType.Celo:
+        return CELO_NETWORK_ID;
+      case BlockchainType.Ethereum:
+        return ETHEREUM_NETWORK_ID;
+      default:
+        return null;
+    }
   }
 }


### PR DESCRIPTION
- does not include choosing provider based on user input, possible to add
- market rates are currently being sent directly to the provider, needs to be discussed
- current implementation allows mixed providers between the tokens. if baseToken exists in provider 1, and quote token exists only on provider 2, the data will be made from the mix. it is visible in the final result in provider: provider1/provider2
- performance is good, just as before
- could be abstracted further by delegating information to the deployment service, i chose not to in this pr to avoid clutter